### PR TITLE
为read.obo函数增加3个主要分类的输出

### DIFF
--- a/R/read-obo.R
+++ b/R/read-obo.R
@@ -45,6 +45,7 @@ extract_obo_item <- function(item) {
     if (!is.na(useless)) return(NULL)
 
     id <- get_obo_info(item, "^id:")
+    level <- get_obo_info(item, "^namespace:")
     name <- get_obo_info(item, "^name:")
     alt_id <- get_obo_info(item, "^alt_id:")
     synonym <- get_obo_info(item, "^synonym:")
@@ -55,7 +56,7 @@ extract_obo_item <- function(item) {
 
     isa <- get_obo_info(item, '^is_a:')
     isa <- sub("\\s*!.*", "", isa)
-    res <- list(do=c(id=id, name=name, def=def),
+    res <- list(do=c(id=id, name=name, def=def, level = level),
         alias = data.frame(id = id, alias = alt_id),
         synonym = data.frame(id = id, synonym = synonym),
         relationship = data.frame(id=id, parent=isa))
@@ -69,7 +70,3 @@ get_obo_info <- function(item, pattern) {
             sub(pattern, "", item[i])
     )
 }
-
-
-
-


### PR DESCRIPTION
Y叔您好，在使用您的read.obo函数解析obo文件时，发现无法解析出obo文件中的BP, MF, CC 的信息，所以对函数做了简单的修改实现了上述三个分类的解析，信息保存在list的info元素对应的df中，obo文件地址：https://purl.obolibrary.org/obo/go/go-basic.obo